### PR TITLE
Add option to auto stop after translation

### DIFF
--- a/src/ConfigManager.cs
+++ b/src/ConfigManager.cs
@@ -88,6 +88,7 @@ namespace UGTLive
         // OCR Processing Mode removed - replaced by Universal Block Detector
         public const string OVERLAY_CLEAR_DELAY_SECONDS = "overlay_clear_delay_seconds";
         public const string PAUSE_OCR_WHILE_TRANSLATING = "pause_ocr_while_translating";
+        public const string STOP_AFTER_TRANSLATING = "stop_after_translating";
         public const string ENABLE_CLOUD_OCR_COLOR_CORRECTION = "enable_cloud_ocr_color_correction";
 
         // Supported OCR methods (internal IDs)
@@ -1044,6 +1045,21 @@ Here is the input JSON:";
             _configValues[PAUSE_OCR_WHILE_TRANSLATING] = enabled.ToString().ToLower();
             SaveConfig();
             Console.WriteLine($"Pause OCR while translating enabled: {enabled}");
+        }
+
+        // Check if stop after translating is enabled
+        public bool IsStopAfterTranslatingEnabled()
+        {
+            string value = GetValue(STOP_AFTER_TRANSLATING, "false");
+            return value.ToLower() == "true";
+        }
+
+        // Set stop after translating enabled
+        public void SetStopAfterTranslatingEnabled(bool enabled)
+        {
+            _configValues[STOP_AFTER_TRANSLATING] = enabled.ToString().ToLower();
+            SaveConfig();
+            Console.WriteLine($"Stop after translating enabled: {enabled}");
         }
 
         // Check if cloud OCR color correction is enabled

--- a/src/Logic.cs
+++ b/src/Logic.cs
@@ -214,6 +214,17 @@ namespace UGTLive
                 MainWindow.Instance.HideTranslationStatus();
                 ChatBoxWindow.Instance?.HideTranslationStatus();
             }
+
+            // Check if we should auto-stop after one cycle
+            if (MainWindow.Instance.ShouldAutoStopAfterOneCycle())
+            {
+                // Stop processing on UI thread
+                Application.Current?.Dispatcher.Invoke(() =>
+                {
+                    MainWindow.Instance.StopProcessing();
+                });
+                return; // Don't re-enable OCR if we're stopping
+            }
             
             // Re-enable OCR if it was paused during translation
             if (ConfigManager.Instance.IsPauseOcrWhileTranslatingEnabled())

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -77,6 +77,7 @@ namespace UGTLive
         
         public bool GetOCRCheckIsWanted() { return _bOCRCheckIsWanted; }
         private bool isStarted = false;
+        private bool _autoStopAfterOneCycle = false;
         private DispatcherTimer _captureTimer;
         private string outputPath = DEFAULT_OUTPUT_PATH;
         private WindowInteropHelper helper;
@@ -941,6 +942,7 @@ namespace UGTLive
             {
                 Logic.Instance.ResetHash();
                 isStarted = false;
+                _autoStopAfterOneCycle = false; // Clear auto-stop flag
                 btn.Content = "Start";
                 btn.Background = new SolidColorBrush(Color.FromRgb(20, 180, 20)); // Green
                 // Clear text objects when stopping to prevent stale overlays
@@ -971,8 +973,44 @@ namespace UGTLive
                 SetOCRCheckIsWanted(true);
                 btn.Background = new SolidColorBrush(Color.FromRgb(220, 0, 0)); // Red
                 
+                // Enable auto-stop after one cycle completes if setting is enabled
+                _autoStopAfterOneCycle = ConfigManager.Instance.IsStopAfterTranslatingEnabled();
+                
                 // Show OCR status when starting (handled by Logic.cs)
             }
+        }
+
+        public bool ShouldAutoStopAfterOneCycle()
+        {
+            return _autoStopAfterOneCycle;
+        }
+
+        public void StopProcessing()
+        {
+            if (!isStarted)
+            {
+                return; // Already stopped
+            }
+
+            Logic.Instance.ResetHash();
+            isStarted = false;
+            _autoStopAfterOneCycle = false; // Clear auto-stop flag
+            
+            // Update button if available
+            if (toggleButton != null)
+            {
+                toggleButton.Content = "Start";
+                toggleButton.Background = new SolidColorBrush(Color.FromRgb(20, 180, 20)); // Green
+            }
+            
+            // Clear text objects when stopping to prevent stale overlays
+            Logic.Instance.ClearAllTextObjects();
+            // Also hide the ChatBox "Waiting for translation" indicator (if visible)
+            ChatBoxWindow.Instance?.HideTranslationStatus();
+            
+            // Hide OCR status when stopping
+            Logic.Instance.HideOCRStatus();
+            HideTranslationStatus();
         }
 
         

--- a/src/SettingsWindow.xaml
+++ b/src/SettingsWindow.xaml
@@ -233,27 +233,37 @@
                                          Unchecked="PauseOcrWhileTranslatingCheckBox_CheckedChanged"
                                          ToolTip="When enabled, OCR will pause while waiting for translation to complete, saving processing power"/>
                                          
+                                <!-- Stop After Translating -->
+                                <TextBlock Text="Stop after translating:" Grid.Row="3" Grid.Column="0"
+                                          VerticalAlignment="Center" Margin="0,0,10,0"
+                                          ToolTip="When enabled, detection will automatically stop after completing one translation cycle"/>
+                                <CheckBox x:Name="stopAfterTranslatingCheckBox" Grid.Row="3" Grid.Column="1"
+                                         Margin="0,5" IsChecked="False"
+                                         Checked="StopAfterTranslatingCheckBox_CheckedChanged"
+                                         Unchecked="StopAfterTranslatingCheckBox_CheckedChanged"
+                                         ToolTip="When enabled, detection will automatically stop after completing one translation cycle"/>
+                                         
                                 <!-- Minimum Text Fragment Size -->
-                                <TextBlock Text="Smallest text fragment:" Grid.Row="3" Grid.Column="0" 
+                                <TextBlock Text="Smallest text fragment:" Grid.Row="4" Grid.Column="0" 
                                           VerticalAlignment="Center" Margin="0,0,10,0"
                                           ToolTip="Minimum number of characters for a text fragment to be processed. Smaller fragments will be ignored."/>
-                                <TextBox x:Name="minTextFragmentSizeTextBox" Grid.Row="3" Grid.Column="1" 
+                                <TextBox x:Name="minTextFragmentSizeTextBox" Grid.Row="4" Grid.Column="1" 
                                         Margin="0,5" Text="2" LostFocus="MinTextFragmentSizeTextBox_LostFocus"
                                         ToolTip="Minimum number of characters for a text fragment to be processed. Smaller fragments will be ignored."/>
                                 
                                 <!-- Minimum Letter Confidence -->
-                                <TextBlock x:Name="minLetterConfidenceLabel" Text="Min letter confidence:" Grid.Row="4" Grid.Column="0" 
+                                <TextBlock x:Name="minLetterConfidenceLabel" Text="Min letter confidence:" Grid.Row="5" Grid.Column="0" 
                                           VerticalAlignment="Center" Margin="0,0,10,0"
                                           ToolTip="Minimum confidence threshold for individual letters/characters (0.0-1.0). Characters with confidence below this threshold will be filtered out."/>
-                                <TextBox x:Name="minLetterConfidenceTextBox" Grid.Row="4" Grid.Column="1" 
+                                <TextBox x:Name="minLetterConfidenceTextBox" Grid.Row="5" Grid.Column="1" 
                                         Margin="0,5" Text="0.1" LostFocus="MinLetterConfidenceTextBox_LostFocus"
                                         ToolTip="Minimum confidence threshold for individual letters/characters (0.0-1.0). Characters with confidence below this threshold will be filtered out."/>
                                 
                                 <!-- Minimum Line Confidence -->
-                                <TextBlock x:Name="minLineConfidenceLabel" Text="Min line confidence:" Grid.Row="5" Grid.Column="0" 
+                                <TextBlock x:Name="minLineConfidenceLabel" Text="Min line confidence:" Grid.Row="6" Grid.Column="0" 
                                           VerticalAlignment="Center" Margin="0,0,10,0"
                                           ToolTip="Minimum confidence threshold for text lines (0.0-1.0). Lines with average confidence below this threshold will be filtered out."/>
-                                <TextBox x:Name="minLineConfidenceTextBox" Grid.Row="5" Grid.Column="1" 
+                                <TextBox x:Name="minLineConfidenceTextBox" Grid.Row="6" Grid.Column="1" 
                                         Margin="0,5" Text="0.2" LostFocus="MinLineConfidenceTextBox_LostFocus"
                                         ToolTip="Minimum confidence threshold for text lines (0.0-1.0). Lines with average confidence below this threshold will be filtered out."/>
                                 

--- a/src/SettingsWindow.xaml.cs
+++ b/src/SettingsWindow.xaml.cs
@@ -455,6 +455,13 @@ namespace UGTLive
                 Console.WriteLine($"Settings window: Loading pause OCR while translating from config: {ConfigManager.Instance.IsPauseOcrWhileTranslatingEnabled()}");
             }
             
+            // Get stop after translating setting from config
+            stopAfterTranslatingCheckBox.IsChecked = ConfigManager.Instance.IsStopAfterTranslatingEnabled();
+            if (ConfigManager.Instance.GetLogExtraDebugStuff())
+            {
+                Console.WriteLine($"Settings window: Loading stop after translating from config: {ConfigManager.Instance.IsStopAfterTranslatingEnabled()}");
+            }
+            
             // Load Cloud OCR Color Correction
             if (cloudOcrColorCorrectionCheckBox != null)
             {
@@ -959,6 +966,21 @@ namespace UGTLive
             
             // Save to config
             ConfigManager.Instance.SetPauseOcrWhileTranslatingEnabled(isEnabled);
+        }
+
+        private void StopAfterTranslatingCheckBox_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            // Skip if initializing to prevent overriding values from config
+            if (_isInitializing)
+            {
+                return;
+            }
+
+            bool isEnabled = stopAfterTranslatingCheckBox.IsChecked ?? false;
+            Console.WriteLine($"Settings window: Stop after translating changed to {isEnabled}");
+
+            // Save to config
+            ConfigManager.Instance.SetStopAfterTranslatingEnabled(isEnabled);
         }
         
         private void CloudOcrColorCorrectionCheckBox_CheckedChanged(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This PR includes a new checkbox option under the `OCR & Detection` settings tab to `Stop after translating`.

This is a UX improvement so that the user is no longer required to continuously monitor the OCR and translation progress and then manually toggle to Stop to prevent the continuous looping.

<img width="752" height="115" alt="image" src="https://github.com/user-attachments/assets/a5ee4aa3-b43e-4c51-8f1c-d4b96efd0d06" />
