### PR TITLE
Add option to persist MainWindow size

### DIFF
--- a/src/ConfigManager.cs
+++ b/src/ConfigManager.cs
@@ -89,6 +89,11 @@ namespace UGTLive
         public const string OVERLAY_CLEAR_DELAY_SECONDS = "overlay_clear_delay_seconds";
         public const string PAUSE_OCR_WHILE_TRANSLATING = "pause_ocr_while_translating";
         public const string ENABLE_CLOUD_OCR_COLOR_CORRECTION = "enable_cloud_ocr_color_correction";
+        public const string PERSIST_WINDOW_SIZE = "persist_window_size";
+        public const string OCR_WINDOW_LEFT = "ocr_window_left";
+        public const string OCR_WINDOW_TOP = "ocr_window_top";
+        public const string OCR_WINDOW_WIDTH = "ocr_window_width";
+        public const string OCR_WINDOW_HEIGHT = "ocr_window_height";
 
         // Supported OCR methods (internal IDs)
         private static readonly IReadOnlyList<string> _supportedOcrMethods = new List<string>
@@ -2950,6 +2955,85 @@ Here is the input JSON:";
             _configValues[WINDOWS_VISIBLE_IN_SCREENSHOTS] = visible.ToString().ToLower();
             SaveConfig();
             Console.WriteLine($"Windows visible in screenshots set to: {visible}");
+        }
+
+        // Check if persist window size is enabled
+        public bool IsPersistWindowSizeEnabled()
+        {
+            return GetBoolValue(PERSIST_WINDOW_SIZE, false);
+        }
+
+        // Set persist window size enabled
+        public void SetPersistWindowSizeEnabled(bool enabled)
+        {
+            _configValues[PERSIST_WINDOW_SIZE] = enabled.ToString().ToLower();
+            SaveConfig();
+            Console.WriteLine($"Persist window size enabled: {enabled}");
+        }
+
+        // Get/Set OCR window position and size
+        public double GetOcrWindowLeft()
+        {
+            string value = GetValue(OCR_WINDOW_LEFT, "");
+            if (double.TryParse(value, out double left))
+            {
+                return left;
+            }
+            return double.NaN;
+        }
+
+        public void SetOcrWindowLeft(double left)
+        {
+            _configValues[OCR_WINDOW_LEFT] = left.ToString();
+            SaveConfig();
+        }
+
+        public double GetOcrWindowTop()
+        {
+            string value = GetValue(OCR_WINDOW_TOP, "");
+            if (double.TryParse(value, out double top))
+            {
+                return top;
+            }
+            return double.NaN;
+        }
+
+        public void SetOcrWindowTop(double top)
+        {
+            _configValues[OCR_WINDOW_TOP] = top.ToString();
+            SaveConfig();
+        }
+
+        public double GetOcrWindowWidth()
+        {
+            string value = GetValue(OCR_WINDOW_WIDTH, "");
+            if (double.TryParse(value, out double width))
+            {
+                return width;
+            }
+            return double.NaN;
+        }
+
+        public void SetOcrWindowWidth(double width)
+        {
+            _configValues[OCR_WINDOW_WIDTH] = width.ToString();
+            SaveConfig();
+        }
+
+        public double GetOcrWindowHeight()
+        {
+            string value = GetValue(OCR_WINDOW_HEIGHT, "");
+            if (double.TryParse(value, out double height))
+            {
+                return height;
+            }
+            return double.NaN;
+        }
+
+        public void SetOcrWindowHeight(double height)
+        {
+            _configValues[OCR_WINDOW_HEIGHT] = height.ToString();
+            SaveConfig();
         }
         
         // Debug logging settings

--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
         mc:Ignorable="d"
         Title="Transparent Screen Capture" 
-        Height="600" Width="800"
+        Height="{Binding InitialHeight}" Width="{Binding InitialWidth}"
         WindowStyle="None"
         ResizeMode="CanResizeWithGrip"
         AllowsTransparency="True"

--- a/src/SettingsWindow.xaml
+++ b/src/SettingsWindow.xaml
@@ -124,6 +124,7 @@
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 
                                 <!-- Log Extra Debug Stuff Checkbox -->
@@ -141,6 +142,14 @@
                                          Unchecked="WindowsVisibleInScreenshotsCheckBox_CheckedChanged"
                                          Content="Make our windows visible in screenshots (Don't turn this on!)"
                                          ToolTip="If checked, ChatBox, Monitor, and MainWindow overlays will be visible in screenshots. Uncheck (default) to exclude them from screen captures. (Don't turn this on, it breaks the app!)"/>
+                                
+                                <!-- Persist Window Position Checkbox -->
+                                <CheckBox x:Name="persistWindowSizeCheckBox" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                         Margin="0,5" IsChecked="False" 
+                                         Checked="PersistWindowSizeCheckBox_CheckedChanged" 
+                                         Unchecked="PersistWindowSizeCheckBox_CheckedChanged"
+                                         Content="Persist window position and size"
+                                         ToolTip="If checked, the main window's position and size will be saved and restored when the application restarts."/>
                             </Grid>
                         </GroupBox>
                         

--- a/src/SettingsWindow.xaml.cs
+++ b/src/SettingsWindow.xaml.cs
@@ -471,6 +471,9 @@ namespace UGTLive
             // Load debug logging settings
             logExtraDebugStuffCheckBox.IsChecked = ConfigManager.Instance.GetLogExtraDebugStuff();
             
+            // Load persist window size setting
+            persistWindowSizeCheckBox.IsChecked = ConfigManager.Instance.IsPersistWindowSizeEnabled();
+            
             // Load colors and update UI
             Color bgColor = ConfigManager.Instance.GetMonitorOverrideBgColor();
             Color fontColor = ConfigManager.Instance.GetMonitorOverrideFontColor();
@@ -1629,6 +1632,17 @@ googleVisionKeepLinefeedsCheckBox.Visibility = glueVisibility;
             bool enabled = logExtraDebugStuffCheckBox.IsChecked ?? false;
             ConfigManager.Instance.SetLogExtraDebugStuff(enabled);
             Console.WriteLine($"Log extra debug stuff: {enabled}");
+        }
+
+        private void PersistWindowSizeCheckBox_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            // Skip if initializing
+            if (_isInitializing)
+                return;
+                
+            bool enabled = persistWindowSizeCheckBox.IsChecked ?? false;
+            ConfigManager.Instance.SetPersistWindowSizeEnabled(enabled);
+            Console.WriteLine($"Persist window size: {enabled}");
         }
 
         private void OverrideBgColorButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This PR includes a new checkbox option to `Persist Window Size` under the `General` settings tab.

It will save the MainWindow position, width, and height to the config so the user does not need to manually resize and position it every time the app is opened if using for the same purpose.

<img width="732" height="131" alt="image" src="https://github.com/user-attachments/assets/ac00c00b-65e8-42ed-8089-828d5f12da73" />
